### PR TITLE
Fix token parsing bug in router

### DIFF
--- a/config/router.go
+++ b/config/router.go
@@ -107,12 +107,13 @@ func authMiddleware(apiKey string) gin.HandlerFunc {
 			helper.ErrorResponse(c, http.StatusUnauthorized, helper.ErrMissingToken)
 			return
 		}
-		splitToken := strings.Split(authorization, "Bearer ")
-		tokenString := splitToken[1]
-		if len(splitToken) < 2 {
+
+		parts := strings.SplitN(authorization, "Bearer ", 2)
+		if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
 			helper.ErrorResponse(c, http.StatusUnauthorized, helper.ErrMissingToken)
 			return
 		}
+		tokenString := strings.TrimSpace(parts[1])
 
 		// Parse the token
 		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {


### PR DESCRIPTION
## Summary
- fix index out-of-range bug when extracting bearer token

## Testing
- `go test ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_683fc4e6a154832fb0137ee40007d399